### PR TITLE
Use modal show event for delete confirmation

### DIFF
--- a/recipe_post/templates/recipe_post/recipe_page.html
+++ b/recipe_post/templates/recipe_post/recipe_page.html
@@ -151,7 +151,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn close-btn" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn close-btn" id="confirmDeleteBtn">Delete</button>
+                <button type="button" class="btn close-btn" id="confirmDeleteBtn" data-bs-dismiss="modal">Delete</button>
             </div>
         </div>
     </div>

--- a/static/js/delete.js
+++ b/static/js/delete.js
@@ -1,20 +1,22 @@
 (() => {
   let formSelector = null;
 
-  document.addEventListener('click', (e) => {
-    const trigger = e.target.closest('.js-delete-trigger[data-form]');
-    if (trigger) {
-      formSelector = trigger.getAttribute('data-form');
-    }
-  });
+  const deleteModal = document.getElementById('deleteRecipeModal');
+  if (deleteModal) {
+    deleteModal.addEventListener('show.bs.modal', (event) => {
+      const trigger = event.relatedTarget;
+      formSelector = trigger ? trigger.dataset.form : null;
+    });
+  }
 
-  document.addEventListener('click', (e) => {
-    if (e.target.closest('#confirmDeleteBtn')) {
+  const confirmBtn = document.getElementById('confirmDeleteBtn');
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', () => {
       const form = formSelector ? document.querySelector(formSelector) : null;
       if (!form) { console.warn('[DeleteModal] Form not found:', formSelector); return; }
-      e.target.setAttribute('disabled', 'disabled');
+      confirmBtn.setAttribute('disabled', 'disabled');
       if (form.requestSubmit) form.requestSubmit(); else form.submit();
       formSelector = null;
-    }
-  });
+    });
+  }
 })();

--- a/submissions/templates/submissions/my_submissions.html
+++ b/submissions/templates/submissions/my_submissions.html
@@ -107,7 +107,7 @@
             <div class="modal-body">This action cannot be undone.</div>
             <div class="modal-footer">
                 <button type="button" class="btn close-btn" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn close-btn" id="confirmDeleteBtn">Delete</button>
+                <button type="button" class="btn close-btn" id="confirmDeleteBtn" data-bs-dismiss="modal">Delete</button>
             </div>
         </div>
     </div>

--- a/submissions/templates/submissions/submit_recipe.html
+++ b/submissions/templates/submissions/submit_recipe.html
@@ -158,7 +158,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn close-btn" data-bs-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn close-btn" id="confirmDeleteBtn">Delete</button>
+                        <button type="button" class="btn close-btn" id="confirmDeleteBtn" data-bs-dismiss="modal">Delete</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Track the pending form when the delete modal opens via `show.bs.modal`
- Submit stored form on confirm button click and clear reference
- Add `data-bs-dismiss="modal"` to delete confirmation buttons to close modal after submission

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: TypeError: a bytes-like object is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fa693e14832c925b07720ebe9a22